### PR TITLE
build: remove LDFLAGS and CPPFLAGS from unserding.pc

### DIFF
--- a/unserding.pc.in
+++ b/unserding.pc.in
@@ -9,6 +9,6 @@ unserincdir=@pkgincludedir@
 Name: unserding
 Description: Ubiquitous Network Service to Enquire Real or Deduced Information
 Version: @PACKAGE_VERSION@
-Libs: @LDFLAGS@ -L${libdir} -lunserding
-Cflags: @CPPFLAGS@ -I${includedir}
+Libs: -L${libdir} -lunserding
+Cflags: -I${includedir}
 


### PR DESCRIPTION
Adding LDFLAGS seems to be wrong, maybe LIBS could
be needed.

This issue was noticed since Fedora >=23 where they are using
these LDFLAGS for distro builds:

  -Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld

Then it's not possible to compile something against unserding
without using some special CFLAGS too ...